### PR TITLE
Remove dependency on cordova-plugin-wkwebview-engine

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -94,7 +94,6 @@
     <source-file src="src/ios/SDCVolumeButtonObserver.h" />
 
     <dependency id="cordova-plugin-add-swift-support" version="2.0.2"/>
-    <dependency id="cordova-plugin-wkwebview-engine" version="1.1.4"/>
 
     <framework src="src/ios/framework/ScanditCaptureCore.framework" version="6.3.2"
                custom="true" embed="true" />


### PR DESCRIPTION
The plugin `cordova-plugin-wkwebview-engine` should not be listed as a dependency. The `cordova-plugin-wkwebview-engine` plugin was made obsolete by Cordova iOS 6.0.0; it is no longer necessary and it will cause the app to break when it is installed. See: https://cordova.apache.org/announcements/2020/06/01/cordova-ios-release-6.0.0.html

Rather than listing it as a dependency, you should note in the documentation that Cordova projects using Cordova iOS 5.x need to install `cordova-plugin-wkwebview-engine`.

For cordova projects with `scandit-cordova-datacapture-core` installed, when you run the following

    cordova platform rm ios
    cordova platform add ios@6.1.0

then the Scandit plugin will get reinstalled on iOS and this has the consequence of installing the `cordova-plugin-wkwebview-engine` plugin because it is currently listed as a Scandit dependency. 

So to remove the plugin, you have to run

    cordova plugin rm cordova-plugin-wkwebview-engine --force

Then you have to open `plugins/ios.json` and remove `cordova-plugin-wkwebview-engine`. Otherwise when you run `cordova build ios`, you will see the following error message:

    Cannot find plugin.xml for plugin "cordova-plugin-wkwebview-engine". Please try adding it again.