### PR TITLE
fix: Cordova iOS7.0.0 dropped support of podspec type from framework tag

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -100,7 +100,14 @@
 
         <source-file src="src/ios/SDCVolumeButtonObserver.h" />
 
-        <framework src="ScanditCaptureCore" spec="= 6.18.1" type="podspec" />
+        <podspec>
+			<config>
+				<source url="https://cdn.cocoapods.org/"/>
+			</config>
+			<pods use-frameworks="true">
+				<pod name="ScanditCaptureCore" spec="6.18.1"/>
+			</pods>
+		</podspec>
     </platform>
 
     <!-- Android -->


### PR DESCRIPTION
Cordova iOS7.0.0 dropped support of podspec type from framework tag